### PR TITLE
Add: Script to create linelevel PAGE XML files with pseudo baselines.

### DIFF
--- a/bin/frat_json2textline_pagexml
+++ b/bin/frat_json2textline_pagexml
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import html
+import json
+from datetime import datetime
+from itertools import chain
+from pathlib import Path
+
+import fargv
+from PIL import Image
+from shapely import normalize, intersection
+from shapely.geometry import Polygon, MultiPolygon
+
+
+def render_textareas(rects: list, class_ids: list, class_names: list, transcriptions: list, page_poly: Polygon,
+                     baseline_lineheight: int = 0.25) -> str:
+    """ Creates a xml representation string with an overall TextRegion (convex hull) and
+     TextLines with generic baselines """
+    pts = ([Polygon([(l, t), (r, t), (r, b), (l, b)]) for (l, t, r, b) in rects])
+    tr = MultiPolygon(pts).convex_hull
+    tr.buffer(5)
+    tr = normalize(intersection(page_poly, tr))
+
+    attributes = [(f"""<ReadingOrder>
+            <OrderedGroup id="ro_1" caption="Regions reading order">
+                <RegionRefIndexed index="0" regionRef="tr_1"/>
+            </OrderedGroup>
+        </ReadingOrder>
+        <TextRegion id="tr_1" type="paragraph" custom="readingOrder {{index:0;}}">
+	        <Coords points="{' '.join([str(int(x)) + ',' + str(int(y)) for x, y in tr.exterior.coords[:-1]])}"/>""")]
+    for n, ((l, t, r, b), class_id, transcription) in enumerate(zip(rects, class_ids, transcriptions)):
+        # HTML escaping of transcription text is required
+        attributes.append(f"""\n            <TextLine id="tr_1_tl_{n}" custom="readingOrder {{index:{n};}}">
+	            <Coords points="{l},{t} {r},{t} {r},{b} {l},{b}"/>
+	            <Baseline points="{l},{b + int((t - b) * baseline_lineheight)} {r},{b + int((t - b) * baseline_lineheight)}"/>
+	            <TextEquiv>
+	                <Unicode>{html.escape(transcription)}</Unicode>
+	            </TextEquiv>
+	            <TextStyle fontFamily="{class_names[class_id]}"/>
+	        </TextLine>""")
+    attributes.append(f"""	    </TextRegion>""")
+    return "\n".join(attributes)
+
+
+def render_page_xml(json_name: str) -> str:
+    """ Renders a valid PAGE XML (convention with eScriptorium) from a JSON (output of FRAT)"""
+    gt = json.load(open(json_name, "r"))
+    img_fname = json_name[:-5]
+    rects, class_ids, class_names, transcriptions = gt["rect_LTRB"], gt["rect_classes"], gt["class_names"], \
+        gt["rect_captions"]
+    if ("image_wh" in gt.keys()):
+        image_wh = gt["image_wh"]
+    else:
+        image_wh = Image.open(img_fname).size
+    page_poly = Polygon([(0, 0), (image_wh[0], 0), (image_wh[0], image_wh[1]), (0, image_wh[1])])
+    attributes = render_textareas(rects, class_ids, class_names, transcriptions, page_poly)
+    current_date_time = datetime.now()
+    formatted_date_time = current_date_time.strftime("%Y-%m-%dT%H:%M:%S")
+    return f"""<?xml version="1.0" encoding="UTF-8"  standalone="yes"?>
+<PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+	<Metadata>
+	    <Creator>FRAT</Creator>
+	   	<Created>{formatted_date_time}</Created>
+	    <LastChange>{formatted_date_time}</LastChange>
+	    <Comments>Converted from 2 point rectangles</Comments>
+    </Metadata>
+    <Page imageFilename="{Path(img_fname).name}" imageWidth="{image_wh[0]}" imageHeight="{image_wh[1]}">
+        {attributes}
+	</Page>
+</PcGts>
+"""
+
+
+if __name__ == "__main__":
+    p = {
+        "jsons": set([]),
+        "output_postfix": ".page.xml"
+    }
+    p, _ = fargv.fargv(p)
+    print(p)
+    assert p.output_postfix != ""
+    for json_fname in p.jsons:
+        # render_page_xml(json_fname)
+        open(json_fname + p.output_postfix, "w").write(render_page_xml(json_fname))

--- a/bin/frat_json2textline_pagexml
+++ b/bin/frat_json2textline_pagexml
@@ -65,7 +65,16 @@ def render_textareas(rects: list, class_ids: list, class_names: list, transcript
 
 
 def render_page_xml(json_name: str) -> str:
-    """ Renders a valid PAGE XML (convention with eScriptorium) from a JSON (output of FRAT)"""
+    """ Renders a valid PAGE XML (convention with eScriptorium) from a JSON (output of FRAT)
+
+    Extended description:
+    This script only works without errors if no multilines per box were transcribed with Frat.
+    It converts all boxes into TextLine polygons and creates a pseudo-baseline at a height of 25% from
+    the bottom edge of the box. (The psuedobaseline calculation could be extended for other cases.)
+    A convex hull is calculated that encompasses all TextLines and serves as a TextRegion.
+    The rendered file can be imported into various transcription tools such as
+    eScriptorium and used to train layout and transcription models.
+    """
     gt = json.load(open(json_name, "r"))
     img_fname = json_name[:-5]
     rects, class_ids, class_names, transcriptions = gt["rect_LTRB"], gt["rect_classes"], gt["class_names"], \

--- a/bin/frat_json2textline_pagexml
+++ b/bin/frat_json2textline_pagexml
@@ -1,5 +1,27 @@
 #!/usr/bin/env python3
 
+# MIT License
+#
+# Copyright (c) 2023 Jan Kamlah
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import html
 import json
 from datetime import datetime

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering"],
-    install_requires=["Pillow", "jinja2", "cherrypy", "fargv", "tqdm", "opencv-python-headless", "numpy", "opencv-python-headless"],
+    install_requires=["Pillow", "jinja2", "cherrypy", "fargv", "tqdm", "opencv-python-headless", "numpy", "opencv-python-headless", "shapely"],
 )


### PR DESCRIPTION
Hello @anguelos,

we from Mannheim have written another small script to convert the FRAT json to PAGE XML with TextLines files, so we can use it for our training.
The steps are as follows
- Calculate a convex hull over all bounding boxes, which serves as a TextRegion with the type " paragraph " (OCR-D compliant).
- Creation of a ReadingOrder
- Conversion of all bounding boxes into TextLines
- Calculation of a pseudo baseline (25 % of the line height) 
- HTML-Escaping of the texts

Maybe you also have a use for the script.

We would probably also write a small script to recalculate the line polygon and replace a few characters, which would mean major changes to the original data. 